### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/oioki/blog/security/code-scanning/2](https://github.com/oioki/blog/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow to explicitly define the permissions required. Based on the workflow's steps:
- The `actions/checkout@v3` and `actions/upload-artifact@v4` actions require `contents: read` and `contents: write`, respectively.
- The rest of the steps (e.g., setting up Node.js, installing dependencies, and building) do not require additional permissions.

The `permissions` block should be added at the root level to apply to all jobs in the workflow. This ensures that the workflow only has the minimal permissions necessary to function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
